### PR TITLE
Update show_wlan.py

### DIFF
--- a/wlanpi_commands/show_wlan.py
+++ b/wlanpi_commands/show_wlan.py
@@ -54,7 +54,7 @@ class ShowWlan(Command):
         # Extract interface info
         interface_re = re.findall(
             r'^(wlan\d)  ', ifconfig_info, re.DOTALL | re.MULTILINE)
-        if interface_re is None:
+        if not interface_re:
             return "Err: command failed: ifconfig match error."
         else:
             for interface_name in interface_re:


### PR DESCRIPTION
If there isn't a WiFi NIC connected to the WLAN Pi, the service will fail with the following message:

Feb 23 09:45:15 wlanpi python3[5907]: Traceback (most recent call last):
Feb 23 09:45:15 wlanpi python3[5907]:   File "/opt/wlanpi-chat-bot/wlanpi-chat-bot", line 146, in <module>
Feb 23 09:45:15 wlanpi python3[5907]:     main()
Feb 23 09:45:15 wlanpi python3[5907]:   File "/opt/wlanpi-chat-bot/wlanpi-chat-bot", line 131, in main
Feb 23 09:45:15 wlanpi python3[5907]:     msg = GLOBAL_CMD_DICT[command].run(args_list)
Feb 23 09:45:15 wlanpi python3[5907]:   File "/opt/wlanpi-chat-bot/wlanpi_commands/show_wlan.py", line 122, in run
Feb 23 09:45:15 wlanpi python3[5907]:     return self._render(interface_info)
Feb 23 09:45:15 wlanpi python3[5907]: UnboundLocalError: local variable 'interface_info' referenced before assignment

The script "show_wlan.py" is using Regex to look for "wlan" in the output of ifconfig. If it's not there, the logic currently in place to check for that doesn't match to allow a more graceful failure.

Instead of "if interface_re is None:", "if not interface_re:" seems to work.